### PR TITLE
Update about page, switch mail to LinkedIn, auto-update copyright year

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,7 +3,7 @@ languageCode = "en-us"
 title = "Esther Olatunde"
 
 theme = "kiss"
-copyright = "&copy; <a href=\"https://github.com/esteedqueen\">Esther Olatunde</a> 2019"
+copyright = "&copy; <a href=\"https://github.com/esteedqueen\">Esther Olatunde</a>"
 googleAnalytics = "UA-113891354-1"
 # Number of posts per page
 Paginate = 5
@@ -45,7 +45,7 @@ page = "MsEOlatunde" # Twitter Page username. If not set, params.social.twitter 
 
 github = "esteedqueen"
 twitter = "MsEOlatunde"
-email = "ea.olatunde@gmail.com"
+linkedin = "esther-o-3193a11a"
 
 [taxonomies]
 category = "categories"

--- a/content/about.md
+++ b/content/about.md
@@ -6,14 +6,16 @@ type = "page"
 
 {{< figure src="/images/esther.png" class="avatar is-mobile" >}}
 
-Hi, I’m Esther Olatunde - a software engineer from Lagos, Nigeria.
+Hi, I'm Esther Olatunde — a software engineer and founder.
 
-I’m currently a Full Stack Software Developer at [Lexoo](https://www.lexoo.co.uk/) - helping to build one of Europe’s leading legal technology companies.
+I started a company straight out of school ([Tress](https://www.producthunt.com/posts/tress), YC W17) and have been building ever since. The work I love most sits at the intersection of systems thinking, product instinct, and design sensibility. I care about the whole picture: how the system performs at 0 and at scale, how the user feels, and whether the thing we're building actually matters.
 
-Prior to that, I co-founded [Tress](https://www.producthunt.com/posts/tress) (YC W2017) as the CTO and worked as a Senior Developer at a [software consultancy firm](https://www.happybearsoftware.com) building products for businesses in the UK.
+Right now, I'm building a new company at the intersection of AI and the messy, high-stakes operational work — regulated, human-in-the-loop — that runs real businesses: the parts where demos don't survive contact with reality. Stealth-ish, more soon.
 
-One of the reasons why I love programming is that I learn new things everyday. It can get a bit crazy but I absolutely love it. I’ve tried keeping records in private gists but that has gotten a bit scattered and sharing is always a good thing :)
+Before that, I spent five years at [Intercom](https://www.intercom.com), most recently leading Knowledge Foundations for [Fin.ai](https://fin.ai), after earlier years shipping 0-to-1 customer engagement products and working deep in distributed systems, infrastructure, and APIs — the kind of problems where a millisecond matters and a bad abstraction haunts you for years.
 
-This blog is an attempt at documenting my thoughts, learnings and journey in a semi-formal / semi-consistent form.
+Outside of work, I'm a trained yoga instructor. It's the one place where my brain finally stops optimizing. Curiosity is probably the thread that connects everything I do — whether I'm digging into Ruby internals, working through Cryptopals, exploring how LLMs actually work under the hood, or holding a pose I couldn't do six months ago. I once built a [simple HTTP server](https://github.com/esteedqueen/simple-http-server) from scratch because it sounded like fun, and somehow ended up giving a RubyConf talk about it. I'm currently learning Irish, French, and Japanese. At the same time. 😅
 
-A few more random tidbits about me: I’m a newbie yogi, I think I change my hairstyles way too often, I've read and I own all the books in the Harry Potter series, I recently built a [simple http web server](https://github.com/esteedqueen/simple-http-server) from scratch with Ruby, I trained a simple ML classifier that identifies different types of hairstyles ;) using Tensorflow, I’m currently building [MuteEveryone.com](https://twitter.com/muteeveryone) and learning about the Ruby internals.
+If you're building something ambitious — especially in applied AI, infra, or anything that breaks in interesting ways at scale — I'd love to talk.
+
+This blog is an attempt at documenting my thoughts, learnings, and journey in a semi-formal, semi-consistent form.

--- a/content/about.md
+++ b/content/about.md
@@ -6,16 +6,16 @@ type = "page"
 
 {{< figure src="/images/esther.png" class="avatar is-mobile" >}}
 
-Hi, I'm Esther Olatunde — a software engineer and founder.
+Hi, I'm Esther Olatunde, a software engineer and product-minded builder.
 
 I started a company straight out of school ([Tress](https://www.producthunt.com/posts/tress), YC W17) and have been building ever since. The work I love most sits at the intersection of systems thinking, product instinct, and design sensibility. I care about the whole picture: how the system performs at 0 and at scale, how the user feels, and whether the thing we're building actually matters.
 
-Right now, I'm building a new company at the intersection of AI and the messy, high-stakes operational work — regulated, human-in-the-loop — that runs real businesses: the parts where demos don't survive contact with reality. Stealth-ish, more soon.
+Right now, I'm building a new company at the intersection of AI and the messy, high-stakes operational work (regulated, human-in-the-loop) that runs real businesses: the parts where demos don't survive contact with reality. Stealth-ish, more soon.
 
-Before that, I spent five years at [Intercom](https://www.intercom.com), most recently leading Knowledge Foundations for [Fin.ai](https://fin.ai), after earlier years shipping 0-to-1 customer engagement products and working deep in distributed systems, infrastructure, and APIs — the kind of problems where a millisecond matters and a bad abstraction haunts you for years.
+Before that, I spent five years at [Intercom](https://www.intercom.com), most recently leading Knowledge Foundations for [Fin.ai](https://fin.ai), after earlier years shipping 0-to-1 customer engagement products and working deep in distributed systems, infrastructure, and APIs, the kind of problems where a millisecond matters and a bad abstraction haunts you for years.
 
-Outside of work, I'm a trained yoga instructor. It's the one place where my brain finally stops optimizing. Curiosity is probably the thread that connects everything I do — whether I'm digging into Ruby internals, working through Cryptopals, exploring how LLMs actually work under the hood, or holding a pose I couldn't do six months ago. I once built a [simple HTTP server](https://github.com/esteedqueen/simple-http-server) from scratch because it sounded like fun, and somehow ended up giving a RubyConf talk about it. I'm currently learning Irish, French, and Japanese. At the same time. 😅
+Outside of work, I'm a trained yoga instructor. It's the one place where my brain finally stops optimizing. Curiosity is probably the thread that connects everything I do, whether I'm digging into Ruby internals, working through Cryptopals, exploring how LLMs actually work under the hood, or holding a pose I couldn't do six months ago. I once built a [simple HTTP server](https://github.com/esteedqueen/simple-http-server) from scratch because it sounded like fun, and somehow ended up giving a RubyConf talk about it. I'm currently learning Irish, French, and Japanese. At the same time. 😅
 
-If you're building something ambitious — especially in applied AI, infra, or anything that breaks in interesting ways at scale — I'd love to talk.
+If you're building something ambitious, especially in applied AI, infra, or anything that breaks in interesting ways at scale, I'd love to talk.
 
 This blog is an attempt at documenting my thoughts, learnings, and journey in a semi-formal, semi-consistent form.

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,0 +1,25 @@
+{{ partial "header" . }}
+{{ partial "nav" . }}
+<section class="section">
+  <div class="container">
+    {{ range sort .Paginator.Pages }}
+    <article>
+      <h2 class="subtitle is-6">{{ .Date.Format "January 2, 2006" }}</h2>
+      <h1 class="title"><a href="{{ .Permalink }}">{{ .Title }}</a>{{ if .Draft }} ::Draft{{ end }}</h1>
+      <div class="content">
+        {{ .Summary | plainify | safeHTML }}
+        {{ if .Truncated }}
+        <a class="button is-link" href="{{ .Permalink }}" style="height:28px">
+          Read more
+          <span class="icon is-small">
+            <i class="fa fa-angle-double-right"></i>
+          </span>
+        </a>
+        {{ end }}
+      </div>
+    </article>
+    {{ end }}
+  </div>
+</section>
+{{ partial "pager" . }}
+{{ partial "footer" . }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,7 +3,7 @@
 
 <section class="section">
   <div class="container">
-    {{ $paginator := .Paginate (where .Data.Pages "Type" "in" "post") }}
+    {{ $paginator := .Paginate (where .Site.RegularPages "Type" "in" "post") }}
     {{ range $paginator.Pages }}
     <article>
       <h2 class="subtitle is-6">{{ .Date.Format "January 2, 2006" }}</h2>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -17,7 +17,7 @@
         </nav>
       </div>
       <div class="nav-right">
-        <p class="u_padding--default">{{ .Site.Copyright | safeHTML }}</p>
+        <p class="u_padding--default">{{ .Site.Copyright | safeHTML }} {{ now.Year }}</p>
         {{if .Site.Params.Info.poweredby}}
           <p>Powered by <a href="https://gohugo.io/">Hugo</a> &amp; <a href="https://github.com/ribice/kiss">Kiss</a>.</p>
         {{ end }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [context.production.environment]
-  HUGO_VERSION = "0.28"
+  HUGO_VERSION = "0.111.3"
 
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.28"
+  HUGO_VERSION = "0.111.3"


### PR DESCRIPTION
- Rewrite About Me with current bio (founder, ex-Intercom/Fin.ai)
- Replace email social link with LinkedIn
- Render copyright year dynamically via now.Year